### PR TITLE
Fix GRCon20 pages: Add CoC, disable Schedule link

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -132,21 +132,25 @@ menu:
       weight: 70
   grcon/grcon20:
     - identifier: grcon20
-      name: GRCon19
+      name: GRCon20
       url: /grcon/grcon20
       weight: 10
     - identifier: about
       name: About
       url: /grcon/grcon20/about
       weight: 20
-    - identifier: schedule
-      name: Schedule
-      url: https://pretalx.gnuradio.org/grcon20
-      weight: 25
-    - identifier: presentations 
+    #- identifier: schedule
+      #name: Schedule
+      #url: https://pretalx.gnuradio.org/grcon20
+      #weight: 25
+    - identifier: presentations
       name: Presentations
       url: /grcon/grcon20/presentations
       weight: 30
+    - identifier: submit
+      name: Submit
+      url: /grcon/grcon20/submit
+      weight: 35
     - identifier: students
       name: Students
       url: /grcon/grcon20/students

--- a/content/grcon/grcon20/coc.md
+++ b/content/grcon/grcon20/coc.md
@@ -1,0 +1,42 @@
+---
+title: "GNU Radio Conference 2020"
+date: 2020-01-14T22:44:56-08:00
+type: grcon/grcon20
+layout: single
+aliases:
+  - grcon-2020/coc
+  - grcon20/coc
+---
+
+# Our Code of Conduct
+
+In order to keep GRCon a fun, interesting, and positive experience for everybody,
+we expect participants to follow the guidelines, below.
+
+GRCon aims to be a welcoming, open, and cooperative event.
+
+This means we expect collaboration from all the GRCon participants, and for
+everybody to behave respectfully towards all others, including those that are
+different or think differently from yourself. Please be helpful, considerate,
+friendly, and respectful towards all other participants and respect the environment.
+
+We don’t condone harassment or offensive behaviour at our conference.
+We consider it against our values as human beings. We expect all participants to
+follow this Code of Conduct during the conference and related events. This
+includes conference-related social events at off-site locations, and in related
+online communities and social media.
+
+Participants asked to stop any unacceptable behaviour are expected to complys
+immediately. Conference participants violating this Code of Conduct may be
+expelled from the conference without refund, and/or banned from formal
+participation in future events. Please bring any concerns to the immediate
+attention of our coordinating team (contact details below).
+
+Thank you for your help in making GRCon a success and pleasant for all the
+people involved.
+
+## Contact Details
+
+E-mail: coc@gnuradio.org
+
+Or ask any staff member during the event to help you locate a team member.


### PR DESCRIPTION
- CoC was a 404
- Schedule is not yet live, we can add that back once we actually have
  a schedule