### PR TITLE
Remove Google Analytics script

### DIFF
--- a/themes/gnuradio-bootstrap/layouts/partials/base/scripts.html
+++ b/themes/gnuradio-bootstrap/layouts/partials/base/scripts.html
@@ -7,13 +7,3 @@
 <script src="{{ $popper.RelPermalink }}"></script>
 <script src="{{ $bootstrap.RelPermalink }}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_CHTML,local/local"></script>
-
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-86877572-1', 'auto');
-    ga('send', 'pageview');
-</script>


### PR DESCRIPTION
Since we do not even inform, let alone ask our visitors for consent,
this probably isn't GPDR-compatible.

As a EU citizen listed on the website, I care about that.