### PR TITLE
made gr-dark-gray a bit darker

### DIFF
--- a/themes/gnuradio-bootstrap/assets/css/style.scss
+++ b/themes/gnuradio-bootstrap/assets/css/style.scss
@@ -4,7 +4,7 @@ $gr-orange: #ff6905;
 $gr-white: #fff;
 $gr-light-gray: #f2f1f1;
 $gr-blue: #007bff;
-$gr-dark-gray: #72706f;
+$gr-dark-gray: #40403f;
 $gr-green: #0db200;
 
 /* Sticky footer styles -------------------------------------------------- */


### PR DESCRIPTION
We had a complaint that the text on the website was hard to read for someone with poor eyesight (and I'm guessing also a poorly calibrated monitor), due to grey on white background.