### PR TITLE
Getting involved: Now own page, with prominent 'Donate' link

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -105,7 +105,7 @@ menu:
       weight: 62
     - identifier: get_involved
       name: Get Involved
-      url: https://wiki.gnuradio.org/index.php/HowToGetInvolved
+      url: /get-involved/
       weight: 70
   grcon/grcon17:
     - identifier: grcon17

--- a/content/get involved/_index.md
+++ b/content/get involved/_index.md
@@ -1,0 +1,99 @@
++++
+title = "Getting Involved"
+aliases = ["get_involved", "getting involved", "get involved"]
++++
+
+# Contacting the Community
+
+GNU Radio is not a corporation, or a corporate project: We're a community
+project. Hence, we very much live by talking to each other!
+
+The GNU Radio project can be reached
+
+* via Email using the GNU Radio discussion mailing list
+  `discuss-gnuradio@gnu.org`, to which you can sign up
+  [here](https://lists.gnu.org/mailman/listinfo/discuss-gnuradio),
+* via Matrix on our Matrix homeserver, e.g. using
+  [chat.gnuradio.org](https://chat.gnuradio.org), or
+* via IRC in #gnuradio on [libera.chat](https://libera.chat). Those two chat
+  rooms are "bridged", the same messages appear on both.
+
+# Contributing without Writing Code
+
+The GNU Radio community has many motivated programmers – but often, we find
+ourselves in need of help keeping focus, and velocity, on the non-coding side of
+things:
+
+Foremost, you can help by being an active member of the community: Join the
+mailing list and/or the chat, and ask, and discuss!
+
+* You can help by filing [issues on github](https://github.com/gnuradio/gnuradio/issues).
+  Please don't use that to ask usage questions – that's what the contact methods
+  above are for!
+* Read the [official "GNU Radio Academy" tutorials](https://tutorials.gnuradio.org)
+  and tell us what was good – and what wasn't.
+* We host the [GNU Radio Wiki](https://wiki.gnuradio.org). A wiki is a website
+  that everyone can edit! You can help there by
+  * Fixing whenever you find a typo, or a factual error!
+  * Adding information, or short examples, to the blocks you've been using in
+    [the official Block documentation](https://wiki.gnuradio.org/index.php?title=Category:Block_Docs).
+* Give a talk, or advocate for GNU Radio, at your company, university, radio
+  club or wherever you'd be found!
+   * We have the annual GNU Radio conference, where you can submit technical
+     talks, of course, centered around GNU Radio, but also adjacent fields:
+     We've seen talks about radio education, radio astronomy, communication
+     through the strangest media, …. All of them were worthwhile to be held at
+     GRCon.
+   * There's the
+     [European GNU Radio days](https://www.youtube.com/channel/UCFzddPoztcHLuwFWRPJTNrQ/videos),
+     and these are just as great!
+   * If you're coming in from the ham radio side, the [SDR
+     Academy](https://sdra.io/) is a great place to talk!
+* We're also accepting feature requests on the issue tracker - make sure to use
+  the feature request template, and be as clear as possible! A good feature
+  request not only tells us what *you* want GNU Radio to do, but also how it
+  helps the community. If possible, sketch things well enough for us to
+  immediately understand what is meant!
+
+We also have a lot of other community functions that we struggle to fill well.
+For example, if you're planning on participating in GRCon, abd don't mind
+helping out there, please do get in touch; we might even have some small task
+beforehand, which we can't stem ourselves, making something big possible.
+
+If you're already an experienced GNU Radio user, and have an idea for a project
+that a student could do that would benefit the overall GNU Radio community,
+[our Google Summer of Code engagement](https://wiki.gnuradio.org/index.php?title=GSoC)
+would be worth contributing to – by volunteering to become a mentor.
+
+# Contributing by Writing Code
+
+* The [github bug tracker](https://github.com/gnuradio/gnuradio/issues) is ripe
+  with bugs that need fixing – find one, fix it! Sometimes we have entries
+  marked as "good first issue", but that doesn't mean we'd not be happy about
+  *any* kind of bug fix.
+* Review [pull requests](https://github.com/gnuradio/gnuradio/pulls), and
+  comment on them. This is as important as writing code and submitting pull
+  requests, as the hours spent reviewing code our done by a group of people
+  that's smaller than the group of people submitting code!
+* Package things: If you know there's a project (for example, an out-of-tree
+  module) that would benefit from being packaged for your package manager of
+  choice, or if the GNU Radio package on that can be improved, do it. We'll
+  always have an open ear for such endeavours – reach out!
+* Make an addition to GNU Radio: Whether it's a bug fix, or a feature that you
+  think has an audience that is a significant part of the GNU Radio community,
+  do not be frightened to upstream it! If in doubt, even and especially before
+  you even start working on things, the mailing list and chat room has helpful
+  minds.
+
+You'll really want to read the [contributer's guidelines](https://wiki.gnuradio.org/index.php?title=Development).
+
+# Contributing Financially
+
+GNU Radio's financial organisation happens through the [SETI
+Institute](https://www.seti.org), which in the US is a 501(c)(3) charity (that
+means your donations might be tax deductible). If you want to:
+
+## [Donate](https://donorbox.org/gnuradio)
+
+Donations help pay infrastructure bills, give us financial stability allowing us
+to plan GRCon more robustly, and pay for the small things such as stickers.


### PR DESCRIPTION
Now that we have a donorbox link, we should put it *somewhere* on the website.

Since I felt directly dropping users to the wiki when they ask how to get involved was probably not conductive to attracting non-technical contributions, I moved the "Get Involved" page to be part of the main website. Hopefully, that also helps a bit with search engines.