### PR TITLE
Add new GSoC landing page

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -101,6 +101,10 @@ menu:
       name: Donate
       url: https://donorbox.org/gnuradio
       weight: 100
+    - identifier: gsoc
+      name: GSoC '23
+      url: /gsoc/
+      weight: 110
   grcon/grcon17:
     - identifier: grcon17
       name: GRCon17

--- a/content/gsoc/_index.md
+++ b/content/gsoc/_index.md
@@ -1,0 +1,31 @@
++++
+title = "Google Summer of Code 2023"
+aliases = ["gsoc"]
++++
+
+[Google Summer of Code](https://summerofcode.withgoogle.com/) is a global, online program focused on bringing new contributors into open source software development. GSoC Contributors work with an open source organization on a 10 - 22 week programming project under the guidance of mentors. GNU Radio has participated in GSoC since 2012 with a high success rate. We are applying for GSoC 2023, so stay tuned!
+
+## Interested?
+
+##### 1. Make sure you are eligible
+- You must be at least 18 years of age when you register.
+- You must be eligible to work in the country you will reside in during the program.
+- You must be an open source beginner or a student.
+- You have not been accepted as a GSoC Contributor/Student in GSoC more than once.
+- You must reside in a country that is not currently embargoed by the United States.
+
+
+##### 2. Get in touch with us
+- Introduce yourself on [the mailing list](https://lists.gnu.org/mailman/listinfo/discuss-gnuradio). 
+- Read [the ideas list](https://wiki.gnuradio.org/index.php?title=GSoCIdeas) to get a feel for what kind of work you can do at GNU Radio.
+- Read [the contributor instructions](https://wiki.gnuradio.org/index.php?title=GSoCStudentInfo) and [the rules and expectations](https://wiki.gnuradio.org/index.php?title=GSoCManifest).
+- Use GNU Radio! 
+
+##### 3. Apply (Deadline April 4 - 18:00 UTC)
+
+- Find out what you want to do. This could be something from the ideas list, but it doesn't have to be. Get creative! 
+- Send us an early draft of your project proposal. This is kind of a hack, because it enables us to give you feedback on your proposal before the deadline. You can use this feedback to make your proposal even better! Just make sure you have read [the contributor instructions](https://wiki.gnuradio.org/index.php?title=GSoCStudentInfo) before submitting your proposal.
+
+- - -
+
+Many good ideas from previous years are on the old ideas list. If you are interested in one of these ideas try to contact the mentor and also send messages to the GNU Radio mailing list and chat. For previous and currently ongoing projects, read [the page of past GSoC projects](https://wiki.gnuradio.org/index.php?title=GSoCPastProjects).


### PR DESCRIPTION
Proposal for new GSoC landing page. The intention is to make it easier for students and other potential contributors to find info about GSoC. I suppose it replaces https://wiki.gnuradio.org/index.php/GSoC

I'm happy to receive feedback about the text.

![Screenshot 2023-01-29 at 20-49-16 Google Summer of Code 2023 · GNU Radio](https://user-images.githubusercontent.com/1413378/215355043-dd75cc90-7ee4-4ead-a190-f90ece72204f.png)
