### PR TITLE
Navigation: clean up menu bar

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -112,24 +112,24 @@ menu:
       parent: events
       weight: 55
 #
-    - identifier: get_involved
-      name: Community & Contact
+    - identifier: community
+      name: Community
       weight: 80
     - identifier: contact
-      name: Contact the Community
+      name: Get in Touch & Get Involved
       url: /community/
       weight: 10
-      parent: get_involved
+      parent: community
     - identifier: source
       name: Work on the Source Code
       url: https://github.com/gnuradio/gnuradio
       weight: 20
-      parent: get_involved
+      parent: community
     - identifier: gsoc
       name: "GSoC '23"
       url: /gsoc/
       weight: 90
-      parent: get_involved
+      parent: community
 #
     - identifier: donate
       name: Donate

--- a/config.yml
+++ b/config.yml
@@ -41,20 +41,48 @@ menu:
   main:
     - identifier: about
       name: About
-      url: /about/
       weight: 10
+    - identifier: about_gr
+      name: About GNU Radio
+      url: /about/
+      parent: about
+      weight: 10
+    - identifier: about_org
+      name: Leadership
+      url: /org/organization/
+      parent: about
+      weight: 20
+#        
+    - identifier: articles
+      name: News
+      weight: 20
     - identifier: blog
       name: Blog
       url: /blog/
-      weight: 20
+      weight: 10
+      parent: articles
     - identifier: news
       name: News
       url: /news/
-      weight: 30
+      weight: 20
+      parent: articles
+#
     - identifier: docs
       name: Documentation
-      url: /docs/
       weight: 40
+    - name: Installation
+      url: https://wiki.gnuradio.org/index.php/InstallingGR
+      weight: 10
+      parent: docs
+    - name: 📖 Tutorials
+      url: https://wiki.gnuradio.org/index.php/Tutorials
+      weight: 20
+      parent: docs
+    - name: Block Documentation
+      url: https://wiki.gnuradio.org/index.php?title=Category:Block_Docs
+      weight: 30
+      parent: docs
+#
     - identifier: events
       name: Events
       weight: 50
@@ -83,28 +111,30 @@ menu:
       url: /events/
       parent: events
       weight: 55
-    - name: Installing
-      url: https://wiki.gnuradio.org/index.php/InstallingGR
-      weight: 60
-    - name: Tutorials
-      url: https://wiki.gnuradio.org/index.php/Tutorials
-      weight: 70
+#
     - identifier: get_involved
-      name: Community
-      url: /community/
+      name: Community & Contact
       weight: 80
-    - identifier: about_org
-      name: Leadership
-      url: /org/organization/
+    - identifier: contact
+      name: Contact the Community
+      url: /community/
+      weight: 10
+      parent: get_involved
+    - identifier: source
+      name: Work on the Source Code
+      url: https://github.com/gnuradio/gnuradio
+      weight: 20
+      parent: get_involved
+    - identifier: gsoc
+      name: "GSoC '23"
+      url: /gsoc/
       weight: 90
+      parent: get_involved
+#
     - identifier: donate
       name: Donate
       url: https://donorbox.org/gnuradio
       weight: 100
-    - identifier: gsoc
-      name: GSoC '23
-      url: /gsoc/
-      weight: 110
   grcon/grcon17:
     - identifier: grcon17
       name: GRCon17


### PR DESCRIPTION
Navigation bar was super cluttered. Multiple lines in a navigational menu is probably a Bad Thing<sup>:tm:</sup>.

Before: 
![Before](https://github.com/gnuradio/hugo-website/assets/958972/9a1a1d30-bf36-45b3-83ce-8fac11d5db7d)

After:
![After](https://github.com/gnuradio/hugo-website/assets/958972/7b90df77-a8f5-4c20-a6c1-425de9036040)

Structure:

- About
  - About GNU Radio
  - Leadership
- News
  - Blog
  - News
- Documentation
  - Installation
  - 📖 Tutorials
  - Block Documentation
- Events
  - GNU Radio Conference 2023
  - GNU Radio Conference 2022
  - GNU Radio Conference 2021
  - Previous GNU Radio Conferences
  - Other Events
- Community & Contact
  - Get in Touch & Get Involved
  - Work on the Source Code
  - GSoC '23
- Donate
