### PR TITLE
Added unsafe renderer so it always generates what we tell it to

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -9,6 +9,10 @@ disablePathToLower: true
 enableRobotsTXT: true
 assetDir: assets/
 summaryLength: 20
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
 taxonomies:
   tag: tags
   category: categories


### PR DESCRIPTION
When I tried generating the pages locally by running `hugo` I noticed it wasnt including `<img src...` tags, but instead replacing them with `<!-- raw HTML omitted -->` and this fixes it