### PR TITLE
Upgrade hugo to 0.124.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       only:
         - master
     docker:
-      - image: gnuradio/hugo:latest
+      - image: hugomods/hugo:exts-0.124.1
     steps:
       - run: 'eval $(ssh-agent -s)'
       - add_ssh_keys:


### PR DESCRIPTION
The carrousel and clients components dont seem to work with the old version of hugo that circleci was using (v0.53 BuildDate: 2018-12-24) so I'm trying out a public version from https://docker.hugomods.com/