### PR TITLE
Update the matrix link to join the space

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -49,7 +49,7 @@
                           {{ .Content }}
                         </div>
                         <!-- /#post-content -->
-                        {{ if .Site.DisqusShortname }}
+                        {{ if .Site.Config.Services.Disqus.Shortname }}
                         <div id="comments">
                             {{ template "_internal/disqus.html" . }}
                         </div>

--- a/layouts/partials/page.html
+++ b/layouts/partials/page.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
       {{ .Content }}
-      {{ if .Site.DisqusShortname }}
+      {{ if .Site.Config.Services.Disqus.Shortname }}
         <div class="disqus-comments">
         {{ template "_internal/disqus.html" . }}
         </div>

--- a/themes/hugo-universal-theme/static/css/custom.css
+++ b/themes/hugo-universal-theme/static/css/custom.css
@@ -11,3 +11,22 @@
 .box-simple {
   min-height: 230px;
 }
+
+a {
+    color: #ff6905;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+a:hover {
+    color: #e55f00; 
+    text-decoration: underline;
+}
+
+a:visited {
+    color: #b34c00;
+}
+
+a:active {
+    color: #cc5500;
+}


### PR DESCRIPTION
Clicking on the link in the current state will ask to log in with a username hosted on chat.gnuradio.org. Additional manipulation is required to add it to a matrix client (when a person already has one set).

The new version of the link will propose to either create an account/install an app from scratch or will just add itself to the already existant matrix client of the user